### PR TITLE
Update summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Home: https://github.com/lk-geimfari/mimesis
 
 Package license: MIT
 
-Summary: Mimesis: fake data generator.
+Summary: Mimesis is a robust data generator for Python that can produce a wide range of fake data in multiple languages.
 
 Development: https://github.com/lk-geimfari/mimesis
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7d7c76ecd680ae48afe8dc4413ef1ef1ee7ef20e16f9f9cb42892add642fc1b2
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
 
@@ -35,7 +35,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'Mimesis: fake data generator.'
+  summary: Mimesis is a robust data generator for Python that can produce a wide range of fake data in multiple languages.
   doc_url: https://mimesis.readthedocs.io/
   dev_url: https://github.com/lk-geimfari/mimesis
 


### PR DESCRIPTION
I suspect the ':' breaks the auto-conversion to the rattler-build format.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
